### PR TITLE
use .items() dict method on configmap.data

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -167,7 +167,7 @@ class Configurator(object):
                                                                   export=True)
 
         password = configmap.data.pop('password')
-        for key, value in configmap.data:
+        for key, value in configmap.data.items():
             try:
                 self.global_options.update(key, json.loads(value))
             except ValueError:


### PR DESCRIPTION
Direct access of configmap.data results in ValueError: too many values to unpack which doesn't get caught for some reason.  Using dictionary items() iterator correctly unpacks the dictionary entries.