### PR TITLE
guard view ref

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -31,7 +31,8 @@ def filter_spec_context(service_instance):
                                  path_set=['name', 'parent',
                                            'datastore', 'network'])
     finally:
-        view_ref.DestroyView()
+        if view_ref:
+            view_ref.DestroyView()
 
 
 class Configurator(object):


### PR DESCRIPTION
fixes: UnboundLocalError: local variable 'view_ref' referenced before assignment
line 34, in filter_spec_context
    view_ref.DestroyView()

I'm not sure about the type of that variable - would that work?