### PR TITLE
byte2int not necessary in py3

### DIFF
--- a/vcenter_operator/masterpassword.py
+++ b/vcenter_operator/masterpassword.py
@@ -106,14 +106,17 @@ class MasterPassword(object):
         except KeyError as e:
             log.error("Unknown key type '{}'".format(type))
             raise e
-        template = templates[six.byte2int(seed[0]) % len(templates)]
+
+        # we need a range of length 1 here, because python3 behaves differently when only
+        # retrieving one char and not a range of chars from a bytestring.
+        template = templates[six.byte2int(seed[0:1]) % len(templates)]
         for i in range(0, len(template)):
             passChars = CHARACTER_CLASSES[template[i]]
-            passChar = passChars[six.byte2int(seed[i + 1]) % len(passChars)]
+            # same here
+            passChar = passChars[six.byte2int(seed[i + 1:i + 2]) % len(passChars)]
             value += passChar
 
         return value
-
 
 def main():
     import sys


### PR DESCRIPTION
script throws an `TypeError: 'int' object is not subscriptable` error when using py3 environment
checked output of `derive()`method in py2 and py3 env via `raise AnsibleError(template)`

py2 message: CvcvnoCvccCvcv
py3 message: CvcvnoCvccCvcv

