### PR TITLE
Keep Changes on Missing VCenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.*
+*.pyc
+*.egg-info

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -307,7 +307,7 @@ class Configurator(object):
         )
         self.os_session = Session(auth=auth)
 
-    def poll_nova(self):
+    def _poll_nova(self):
         if not self.os_session:
             return
 
@@ -321,7 +321,13 @@ class Configurator(object):
 
     def poll(self):
         self.poll_config()
-        self.poll_nova()
+        self._poll_nova()
+
+        # If we fail to update the templates, we rather do not continue
+        # to avoid rendering only half of the deployment
+        if not DeploymentState.poll_templates():
+            return
+
         for host in self.vcenters:
             try:
                 values = self._poll(host)

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -6,7 +6,7 @@ import re
 import ssl
 import time
 
-from collections import deque
+from collections import defaultdict, deque
 from contextlib import contextmanager
 from keystoneauth1.session import Session
 from keystoneauth1.identity.v3 import Password
@@ -65,7 +65,7 @@ class Configurator(object):
         self.domain = domain
         self.os_session = None
         self.vcenters = dict()
-        self.states = deque()
+        self.states = defaultdict(deque)
         self.poll_config()
         self.global_options['cells'] = {}
         self.global_options['domain'] = domain
@@ -322,10 +322,6 @@ class Configurator(object):
     def poll(self):
         self.poll_config()
         self.poll_nova()
-        state = DeploymentState(
-            namespace=self.global_options['namespace'],
-            dry_run=(self.global_options.get('dry_run', 'False') == 'True'))
-
         for host in self.vcenters:
             try:
                 self._reconnect_vcenter_if_necessary(host)
@@ -339,21 +335,26 @@ class Configurator(object):
 
             try:
                 values = self._poll(host)
+                state = DeploymentState(
+                    namespace=self.global_options['namespace'],
+                    dry_run=(self.global_options.get('dry_run', 'False')
+                             == 'True'))
 
                 for options in values['clusters'].values():
                     state.render('vcenter_cluster', options)
 
                 for options in values['datacenters'].values():
                     state.render('vcenter_datacenter', options)
+
+                states = self.states[host]
+                states.append(state)
+
+                if len(states) > 1:
+                    last = states.popleft()
+                    delta = last.delta(states[-1])
+                    delta.apply()
+                else:
+                    states[-1].apply()
             except http.client.HTTPException as e:
                 LOG.warning("%s: %r", host, e)
                 continue
-
-        self.states.append(state)
-
-        if len(self.states) > 1:
-            last = self.states.popleft()
-            delta = last.delta(self.states[-1])
-            delta.apply()
-        else:
-            self.states[-1].apply()

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -369,11 +369,6 @@ class Configurator(object):
             for options in values['datacenters'].values():
                 self._add_code('vcenter_datacenter', options)
 
-        all_values = {'hosts': hosts}
-        all_values.update(self.global_options)
-        all_values.pop('service_instance', None)
-        self._add_code('vcenter_global', all_values)
-
         if len(self.states) > 1:
             last = self.states.popleft()
             delta = last.delta(self.states[-1])

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -252,7 +252,6 @@ class Configurator(object):
                     continue
 
                 values['clusters'][cluster_name] = cluster_options
-                self._add_code('vcenter_cluster', cluster_options)
 
             for availability_zone in availability_zones:
                 cluster_options = self.global_options.copy()
@@ -261,8 +260,6 @@ class Configurator(object):
                 cluster_options.update(availability_zone=availability_zone)
                 values['datacenters'][availability_zone] = cluster_options
 
-            if cluster_options:
-                self._add_code('vcenter_datacenter', cluster_options)
         return values
 
     def _add_code(self, scope, options):
@@ -364,6 +361,13 @@ class Configurator(object):
             except TemplateLoadingFailed as e:
                 LOG.warning("Loading of templates failed: %r", e)
                 return
+
+        for values in hosts.values():
+            for options in values['clusters'].values():
+                self._add_code('vcenter_cluster', options)
+
+            for options in values['datacenters'].values():
+                self._add_code('vcenter_datacenter', options)
 
         all_values = {'hosts': hosts}
         all_values.update(self.global_options)

--- a/vcenter_operator/phelm.py
+++ b/vcenter_operator/phelm.py
@@ -18,11 +18,11 @@ api_client = client.ApiClient()
 
 
 def _remove_empty_from_dict(d):
-    if type(d) is dict:
+    if isinstance(d, dict):
         return dict(
             (k, _remove_empty_from_dict(v)) for k, v in d.items() if
             v and _remove_empty_from_dict(v))
-    elif type(d) is list:
+    elif isinstance(d, list):
         return [_remove_empty_from_dict(v) for v in d if
                 v and _remove_empty_from_dict(v)]
     else:


### PR DESCRIPTION
Previously, there was a global state of all changes the vcenter-operator wanted to apply and it was creating a diff over that.
That means, if a vcenter was "disappearing" (e.g. temporarily offline), it would delete all associated resources.
Since that is rather more likely that the vcenter is just offline, than us decommissioning one, we rather keep the old deployment state.