### PR TITLE
Fix compatibility with kubernetes api 1.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ scrypt==0.8.6
 pyvmomi
 jinja2
 jsonpatch
-kubernetes>=12,<13
+kubernetes>=21,<22
 keystoneauth1
 dumb-init

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -274,8 +274,7 @@ class Configurator(object):
     def poll_config(self):
         configmap = client.CoreV1Api().read_namespaced_config_map(
             namespace=self.namespace,
-            name='vcenter-operator',
-            export=True)
+            name='vcenter-operator')
 
         password = configmap.data.pop('password')
         for key, value in configmap.data.items():

--- a/vcenter_operator/phelm.py
+++ b/vcenter_operator/phelm.py
@@ -38,7 +38,7 @@ def _under_score(name):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
-_IGNORE_PATHS = set(['/status', '/metadata/annotations', '/spec/selector'])
+_IGNORE_PATHS = set(['/status', '/metadata/annotations', '/metadata/managedFields', '/spec/selector', '/spec/ipFamilies', '/spec/clusterIPs'])
 
 
 def serialize(obj):
@@ -208,7 +208,7 @@ class DeploymentState(object):
                 reader = self.get_method(
                     api, 'read', 'namespaced', _under_score(kind))
                 current = serialize(
-                    reader(name, self.namespace, pretty=False, export=True))
+                    reader(name, self.namespace, pretty=False))
             except client.rest.ApiException as e:
                 if e.status == 404:
                     pass

--- a/vcenter_operator/templates.py
+++ b/vcenter_operator/templates.py
@@ -112,8 +112,7 @@ class ConfigMapLoader(PollingLoader):
         try:
             config = client.CoreV1Api().read_namespaced_config_map(
                 namespace='kube-system',
-                name='vcenter-operator',
-                export=False)
+                name='vcenter-operator')
 
             if self.resource_version == config.metadata.resource_version:
                 return


### PR DESCRIPTION
Kubernetes 1.21 does not support the export argument to various "get" calls.
It was added with the intention of removing values added by the server,
but never worked as intended. Instead the values where filtered manually.

Additional values to the filter list have been added, and
the python library has been upgraded to match that version.