### PR TITLE
Do not remove slash from passwords

### DIFF
--- a/vcenter_operator/templates.py
+++ b/vcenter_operator/templates.py
@@ -39,9 +39,6 @@ def _derive_password(ctx, username=None, host=None):
     mpw = MasterPassword(name=username, password=ctx['master_password'])
     password = mpw.derive('long', host)
 
-    if host.startswith('vc-'):
-        return password.replace("/", "")
-
     return password
 
 


### PR DESCRIPTION
Due to some changes, forward-slash seems to work
again in vcenter