### PR TITLE
Do not remove slash from passwords 2nd location

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -105,8 +105,7 @@ class Configurator:
 
     def _connect_vcenter(self, host):
         """Create a connection to host and add it to self.vcenters"""
-        # Vcenter doesn't accept / in password
-        password = self.mpw.derive('long', host).replace("/", "")
+        password = self.mpw.derive('long', host)
 
         if host not in self.vcenters:
             self.vcenters[host] = {


### PR DESCRIPTION
Due to some changes, forward-slash seems to work
again in vcenter.

We also need to fix it in another instance.