### PR TITLE
Switch to upstream dnspython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 dependencies = [
     "attrs",
-    "dnspython @ git+https://github.com/sapcc/dnspython.git@ccloud",
+    "dnspython~=2.3.0",
     "scrypt==0.8.6",
     "pyvmomi",
     "jinja2<4,>=3",


### PR DESCRIPTION
The featureset we use is fairly limited, and
integrated in upstream, so we can avoid keeping
track of version specific branches,
and checking them out