### PR TITLE
Use buildkit features for caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/python:3.10-slim
+# syntax = docker/dockerfile:1.2
+ARG BASE=keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/python:3.10-slim
+FROM $BASE
 LABEL source_repository="https://github.com/sapcc/vcenter-operator"
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-ADD . /usr/src/app
-RUN ./build.sh
+ENV SRC_DIR=/usr/src/vcenter-operator
+ENV PIP_CACHE_DIR=/var/cache/pip
+RUN mkdir -p $PIP_CACHE_DIR $SRC_DIR
+
+WORKDIR $SRC_DIR
+ADD . $SRC_DIR
+
+RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
 apt-get update
 apt-get install -y git
-pip install --only-binary=scrypt --no-cache-dir -e .
+
+pip install --only-binary=scrypt --disable-pip-version-check -e .
 
 # "Fake" a pbr.json to keep our changelog happy
 [ -f vcenter_operator.egg-info/pbr.json ] || (
@@ -13,5 +17,3 @@ EOT
 )
 
 apt-get purge --autoremove -y git
-rm -r /var/lib/apt/lists /var/cache/apt/archives
-mkdir -p /var/cache/apt/archives /var/lib/apt/lists


### PR DESCRIPTION
Instead of deleting the caches, we use the new dockerfile syntax to make docker aware of the cache paths.

For local builds, it should work out of the box, but in the ci it needs adjustents. Possibly it won't make things faster there, as the build there is distributed