### PR TITLE
Fix storing the openstackseed

### DIFF
--- a/kos_operator/crds.py
+++ b/kos_operator/crds.py
@@ -160,7 +160,7 @@ class OpenstackSeed(CustomResourceDefinitionBase):
 
     def execute(self, state, variables):
         seeds = variables.get('seeds', {})
-        seeds[self.item['metadata']['name']] = self.item['spec']
+        seeds[self.item['metadata']['name']] = self.item.copy()
         variables['seeds'] = seeds
         return variables
 


### PR DESCRIPTION
We need the whole object, as the domains are directly under the object and not under spec