### PR TITLE
Read config from Secret

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -261,12 +261,13 @@ class Configurator:
         return self.global_options['own_namespace']
 
     def poll_config(self):
-        configmap = client.CoreV1Api().read_namespaced_config_map(
+        secret = client.CoreV1Api().read_namespaced_secret(
             namespace=self.namespace,
             name='vcenter-operator')
 
-        password = configmap.data.pop('password')
-        for key, value in configmap.data.items():
+        password = b64decode(secret.data.pop('password'))
+        for key, value in secret.data.items():
+            value = b64decode(value)
             try:
                 self.global_options[key] = json.loads(value)
             except ValueError:


### PR DESCRIPTION
Instead of reading our config from a ConfigMap, we read the config from Secret now. This is necessary, because we require passwords and these are not allowed to live in ConfigMaps.