### PR TITLE
Bump kubernetes dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "masterpassword @ git+https://github.com/sapcc/masterpassword@main",
     "pyvmomi",
     "jinja2<4,>=3",
-    "kubernetes~=26.1",
+    "kubernetes~=28.0",
     "keystoneauth1",
     "dumb-init"]
 


### PR DESCRIPTION
We are now on 1.28 everywhere, use matching version