### PR TITLE
prepare kos for antelope

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(include=['kos_operator', 'kos_operator.*']),
     install_requires=[
         'pyOpenSSL==22.0.0',
-        'openstacksdk>=0.19.0,<0.49.0',
+        'openstacksdk==1.0.0',
         'python-openstackclient==5.0.0',
         'python-ironicclient',
         'attrs',


### PR DESCRIPTION
ironic will be upgrading to antelope.

also:

collections.MutableMapping has been deprecated since Python 3.3 and is removed in Python 3.10. 