### PR TITLE
Feature support multiple namespaces of vct CRDs

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -9,8 +9,6 @@ import time
 from contextlib import contextmanager
 from os.path import commonprefix
 
-from keystoneauth1.identity.v3 import Password
-from keystoneauth1.session import Session
 from kubernetes import client
 from masterpassword.masterpassword import MasterPassword
 from pyVim.connect import Disconnect, SmartConnect
@@ -322,7 +320,6 @@ class Configurator:
             try:
                 values = self._poll(host)
                 state = DeploymentState(
-                    namespace=self.global_options['namespace'],
                     dry_run=(self.global_options.get('dry_run', 'False')
                              == 'True'))
 

--- a/vcenter_operator/phelm.py
+++ b/vcenter_operator/phelm.py
@@ -19,7 +19,6 @@ LOG = logging.getLogger(__name__)
 
 @attr.s
 class DeploymentState:
-    namespace = attr.ib()
     dry_run = attr.ib(default=False)
     items = attr.ib(default=attr.Factory(OrderedDict))
     actions = attr.ib(default=attr.Factory(OrderedDict))
@@ -55,7 +54,7 @@ class DeploymentState:
             self.items[_id] = item
 
     def delta(self, other):
-        delta = DeploymentState(namespace=self.namespace)
+        delta = DeploymentState()
         # no ordering necessary for delete
         for k in self.items.keys() - other.items.keys():
             delta.actions[k] = 'delete'


### PR DESCRIPTION
This PR adds the feature to apply the rendered items to the namespace of the template used.
If the namespace is missing in the template, it will log an error and the template will be ignored.

There could be one problem. The vcenter-operator needs to know the namespace of the nova_cells configmap. This might change when nova moves to another namespace and currently the vcenter-operator uses its own [namespace](https://github.com/sapcc/vcenter-operator/blob/fcf1aaca119e0a6f01cd2e30932ea8e648398c16/vcenter_operator/configurator.py#L279-L285).
Can you confirm that this is a problem and should I consider it in this PR?

I removed the namespace from the deployment state as it was not used imo and therefore is confusing.

If you have feedback already, please let me know :)
