### PR TITLE
Support version numbers > 9999

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -573,7 +573,7 @@ class Configurator:
                           service_user, service_username_template)
                 continue
 
-            version = str(int(service_user[-4:]))
+            version = str(int(service_user.removeprefix(service_username_template)))
             # Recreating the ground truth for service-users
             if version not in self.vcenter_service_user_tracker[service][host].keys():
                 self.vcenter_service_user_tracker[service][host][version] = time.time()

--- a/vcenter_operator/vault.py
+++ b/vcenter_operator/vault.py
@@ -281,8 +281,8 @@ class Vault:
         password = service_user_data.get("data", {}).get("password")
 
         if (
-            service_username_template in username
-            and str(int(username[-4:])) == version
+            username.startswith(service_username_template)
+            and str(int(username.removeprefix(service_username_template))) == version
             and self.check_password_strength(password)
         ):
             LOG.info("Found valid username and password for service %s", service)


### PR DESCRIPTION
We hard-coded the versions to be of length 4, because we fill it up to 4 chars with zeroes, but at some far point in the future the version might be higher than 9999. Therefore, we switch to using `removeprefix()` for removing the service_username_template from the username after having checked that the username starts with service_username_template.