### PR TITLE
Drop dumb-init dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "jinja2<4,>=3",
     "kubernetes~=28.0",
     "keystoneauth1",
-    "dumb-init",
     "pyvmomi-extended @ git+https://github.com/sapcc/pyvmomi-extended@main"
     ]
 


### PR DESCRIPTION
It was only needed in very old k8s/containerd setups.