### PR TITLE
Use BB with zeroes for service_user_path for NSX-T

### DIFF
--- a/vcenter_operator/phelm.py
+++ b/vcenter_operator/phelm.py
@@ -11,6 +11,7 @@ from kubernetes import dynamic
 from yaml.error import YAMLError
 
 from vcenter_operator.templates import env, vcenter_service_user_crd_loader
+from vcenter_operator.util import parse_buildingblock
 
 LOG = logging.getLogger(__name__)
 
@@ -84,7 +85,8 @@ class DeploymentState:
 
         if service_type == "nsxt":
             # options['name'] holds the bb information
-            service_user_path = f"{options['region']}/vcenter-operator/{cr_name}/{options['name']}"
+            bb_name = parse_buildingblock(options['name'], leading_zero=True)
+            service_user_path = f"{options['region']}/vcenter-operator/{cr_name}/{bb_name}"
             host = options['name']
             username_path = (
                 "{{{{ "


### PR DESCRIPTION
We create the secret in Vault with a leading zero, so we also have to add the leading zero when checking for the `service_user_path`.