### PR TITLE
Fix key error: host should contain leading zero

### DIFF
--- a/vcenter_operator/phelm.py
+++ b/vcenter_operator/phelm.py
@@ -87,7 +87,7 @@ class DeploymentState:
             # options['name'] holds the bb information
             bb_name = parse_buildingblock(options['name'], leading_zero=True)
             service_user_path = f"{options['region']}/vcenter-operator/{cr_name}/{bb_name}"
-            host = options['name']
+            host = bb_name
             username_path = (
                 "{{{{ "
                 'resolve "vault+kvv2:///secrets/{}/username?version={}"'


### PR DESCRIPTION
```
2026-02-16 14:03:19,431 1 DEBUG vcenter_operator.phelm Template vcenter_cluster/monsoon3/neutron-nsxv3-agent-deployment.yaml.j2 requires service-user management
Traceback (most recent call last):
  File "/usr/local/bin/vcenter-operator", line 8, in <module>
    sys.exit(main())
  File "/usr/src/vcenter-operator/vcenter_operator/cmd.py", line 92, in main
    configurator.poll()
  File "/usr/src/vcenter-operator/vcenter_operator/configurator.py", line 424, in poll
    state.render('vcenter_cluster', options, self.service_users, self.vcenter_service_user_tracker)
  File "/usr/src/vcenter-operator/vcenter_operator/phelm.py", line 57, in render
    result = self._inject_service_user_info_and_render(
  File "/usr/src/vcenter-operator/vcenter_operator/phelm.py", line 122, in _inject_service_user_info_and_render
    latest_version = self._get_latest_active_service_user_version(
  File "/usr/src/vcenter-operator/vcenter_operator/phelm.py", line 153, in _get_latest_active_service_user_version
    if version in vcenter_service_user_tracker[cr_name][host]:
KeyError: 'bb84'
```