### PR TITLE
Use defaultdict for vcenter_service_user_tracker

### DIFF
--- a/tests/service_user_vcenter/test_nsxt_service_user_management.py
+++ b/tests/service_user_vcenter/test_nsxt_service_user_management.py
@@ -16,7 +16,6 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
         self.configurator = Configurator(domain, global_options)
         self.configurator.vcenter_sso = MagicMock()
         self.configurator.vault = MagicMock()
-        self.configurator.vcenter_service_user_tracker = {}
 
     @patch.object(NsxtUserAPIHelper, "connect")
     @patch.object(NsxtUserAPIHelper, "add_user_to_group")

--- a/tests/service_user_vcenter/test_service_user_vcenter.py
+++ b/tests/service_user_vcenter/test_service_user_vcenter.py
@@ -17,7 +17,6 @@ def configurator():
     configurator = Configurator(domain, global_options)
     configurator.vcenter_sso = MagicMock()
     configurator.vault = MagicMock()
-    configurator.vcenter_service_user_tracker = {}
     return configurator
 
 
@@ -82,8 +81,6 @@ def test_service_user_missing_state(configurator):
     configurator.vcenter_sso.create_service_user.return_value = None
 
     time_last_seen = time.time()
-
-    configurator.vcenter_service_user_tracker = {}
 
     configurator._check_service_user_vcenter(
         "test_service_user_template", cr_name, "test_service", "test_host", "test_path", "1"

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -6,6 +6,7 @@ import logging
 import re
 import ssl
 import time
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from os.path import commonprefix
@@ -78,7 +79,7 @@ class Configurator:
         self.vcenters = dict()
         self.service_users = dict()
         self.last_service_user_check = dict()
-        self.vcenter_service_user_tracker = dict()
+        self.vcenter_service_user_tracker = defaultdict(lambda: defaultdict(dict))
         self.states = dict()
         self.vault = Vault(dry_run=self.global_options.get('dry_run', 'False') == 'True')
         self.vcenter_sso = VCenterSSO(dry_run=self.global_options.get('dry_run', 'False') == 'True')
@@ -609,13 +610,6 @@ class Configurator:
         """Check if service-user in vcenter is up to date"""
         current_username = service_username_template + str(latest_version).zfill(4)
 
-        # Check if vcenter_service_user_tracker has an entry for vcenter and service combination
-        if cr_name not in self.vcenter_service_user_tracker:
-            self.vcenter_service_user_tracker[cr_name] = dict()
-
-        if host not in self.vcenter_service_user_tracker[cr_name]:
-            self.vcenter_service_user_tracker[cr_name][host] = dict()
-
         service_users_in_vcenter = self.vcenter_sso.list_service_users(host, service_username_template)
 
         # Check if current_username is in vcenter
@@ -713,13 +707,6 @@ class Configurator:
             LOG.debug("Found pod with service-user %s and version %s - updating last seen timestamp",
                       service_user, version)
 
-            # Check if vcenter_service_user_tracker has an entry for vcenter and service combination
-            if cr_name not in self.vcenter_service_user_tracker:
-                self.vcenter_service_user_tracker[cr_name] = dict()
-
-            if host not in self.vcenter_service_user_tracker[cr_name]:
-                self.vcenter_service_user_tracker[cr_name][host] = dict()
-
             self.vcenter_service_user_tracker[cr_name][host][str(version)] = time.time()
 
     def _check_service_user_nsxt(self, service_user_prefix, cr_name, service_type, region, bb, path,
@@ -735,13 +722,6 @@ class Configurator:
         except Exception as e:
             msg = f"Failed to list users - {e}"
             raise NSXTSkippedError(msg)
-
-        # Check if vcenter_service_user_tracker has an entry for the NSX-T BB
-        if cr_name not in self.vcenter_service_user_tracker:
-            self.vcenter_service_user_tracker[cr_name] = dict()
-
-        if bb not in self.vcenter_service_user_tracker[cr_name]:
-            self.vcenter_service_user_tracker[cr_name][bb] = dict()
 
         # Create current user in NSXT
         if current_username not in active_users:


### PR DESCRIPTION
This reduces code and fixes the previous commit where we skipped creating some things if the NSX-T manager went away - which resulted in some KeyError down the line.