### PR TITLE
 NSXT: Fix user creation for version 4.1

### DIFF
--- a/vcenter_operator/nsxt_user_manager.py
+++ b/vcenter_operator/nsxt_user_manager.py
@@ -234,7 +234,10 @@ class NsxtUserAPIHelper(NsxtLoginHelper):
             "full_name": username,
             "username": username,
             "password": password,
-            "password_change_frequency": 0,
+            # Number of days password is valid
+            # workaround for version 4.1 required
+            # no expiry (0) does not work
+            "password_change_frequency": 9999,
             "status": "ACTIVE"
         }
         params = {"action": "create_user"}


### PR DESCRIPTION
For NSX-T version 4.1, setting the password expiry to 0 (no expiry) allows the user
to be created, but the user cannot log in afterward.
NSX-T requires the password to be reset on first login in this case.
    
As a workaround, set the password expiry to 9999 days instead of 0.
The vcenter-operator already ensures that the password is rotated within
one year