### PR TITLE
 NSX-T: Cache Management User Credentials

### DIFF
--- a/tests/service_user_last_seen/test_last_seen_updater.py
+++ b/tests/service_user_last_seen/test_last_seen_updater.py
@@ -15,6 +15,7 @@ def configurator():
         "dry_run": False,
         "own_namespace": "test_namespace",
         "manage_service_user_passwords": True,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/tests/service_user_vault/test_service_user.py
+++ b/tests/service_user_vault/test_service_user.py
@@ -11,6 +11,7 @@ def configurator():
     """Fixture to create a Configurator instance with mocked dependencies"""
     global_options = {
         "dry_run": False,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/tests/service_user_vault/test_service_user_expired.py
+++ b/tests/service_user_vault/test_service_user_expired.py
@@ -11,6 +11,7 @@ def configurator():
     """Fixture to create a Configurator instance with mocked dependencies"""
     global_options = {
         "dry_run": False,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/tests/service_user_vault/test_service_user_version.py
+++ b/tests/service_user_vault/test_service_user_version.py
@@ -11,6 +11,7 @@ def configurator():
     """Fixture to create a Configurator instance with mocked dependencies"""
     global_options = {
         "dry_run": False,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/tests/service_user_vault/test_vault_cacher.py
+++ b/tests/service_user_vault/test_vault_cacher.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+import pytest
+
+from vcenter_operator.vault import Vault
+from vcenter_operator.vault_cache import NSXTCacheError, NSXTManagementCache
+
+
+@pytest.fixture
+def cacher():
+    """Fixture to create a Caching instance with mocked dependencies"""
+    vault = Vault(dry_run=False)
+    region = "blabla"
+    caching_time = 18000
+
+    cacher = NSXTManagementCache(region, vault, caching_time)
+    return cacher
+
+def test_add_user(cacher):
+    key = "bb100"
+    value = {"password": "supersecure", "username": "user"}
+
+    with mock.patch('vcenter_operator.vault_cache.NSXTManagementCache.renew_pw') as renew:
+        renew.return_value = value
+        secret = cacher.get_secret(key)
+
+    assert value["password"] == secret["password"]
+    assert value["username"] == secret["username"]
+
+def test_cached_pw(cacher):
+    key = "bb100"
+
+    # Set secret
+    with mock.patch('vcenter_operator.vault.Vault.get_secret') as renew:
+        renew.return_value = {"password": "new_supersecure", "username": "user"}
+        cacher.get_secret(key)
+
+    secret = cacher.get_secret(key)
+    assert "new_supersecure" == secret["password"]
+
+def test_expired_pw(cacher):
+    caching_time = -1000
+    key = "bb100"
+
+    value = {"password": "supersecure", "username": "user"}
+    cacher.cache_lifetime = caching_time
+
+    # Set secret
+    with mock.patch('vcenter_operator.vault.Vault.get_secret') as renew:
+        renew.return_value = value
+        cacher.get_secret(key)
+
+    with mock.patch('vcenter_operator.vault.Vault.get_secret') as renew:
+        renew.return_value =  {"password": "new_supersecure", "username": "user"}
+        new_secret = cacher.get_secret(key)
+        assert "new_supersecure" == new_secret["password"]
+
+def test_return_old_cached_pw(cacher):
+    key = "radomKey"
+    value = {"password": "supersecure", "username": "user"}
+
+    # Set secret
+    with mock.patch('vcenter_operator.vault.Vault.get_secret') as inital_pw:
+        inital_pw.return_value = value
+        cacher.get_secret(key)
+
+    # Return cached pw instead of raising an exception
+    with mock.patch('vcenter_operator.vault.Vault.get_secret') as new_pw:
+        new_pw.side_effect = NSXTCacheError("Simulate vault failure")
+        old_cached_pw = cacher.get_secret(key)
+        assert value["password"] == old_cached_pw["password"]
+        assert value["username"] == old_cached_pw["username"]

--- a/tests/service_user_vcenter/test_nsxt_service_user_management.py
+++ b/tests/service_user_vcenter/test_nsxt_service_user_management.py
@@ -3,13 +3,16 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from vcenter_operator.configurator import Configurator
-from vcenter_operator.nsxt_user_manager import NsxtUserAPIHelper
+from vcenter_operator.nsxt_user_manager import NsxtUserAPIHelper, NotAuthorizedError, NSXTSkippedError
+from vcenter_operator.vault_cache import NSXTManagementCache
+
 
 
 class TestNsxtServiceUserManagement(unittest.TestCase):
     def setUp(self):
         global_options = {
             "dry_run": False,
+            "region": "random"
         }
         domain = "test_domain"
 
@@ -17,12 +20,41 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
         self.configurator.vcenter_sso = MagicMock()
         self.configurator.vault = MagicMock()
 
+
+    @patch.object(NsxtUserAPIHelper, "list_users")
+    @patch.object(NSXTManagementCache, "renew_pw")
+    def test_not_authorized(self, fn_cache, fn_list):
+        management_user = {
+            "username": "admin",
+            "password": "admin",
+        }
+
+        service_user_prefix = "userprefix"
+        latest_version = "0002"
+        cr_name = "cr_name"
+        service = "nsxt"
+        bb = "bb085"
+        region = "random"
+        path = f"{service}/{bb}"
+        group = "blabbla"
+
+        fn_list.side_effect = NotAuthorizedError()
+        fn_cache.return_value = management_user
+
+        try:
+            self.configurator._check_service_user_nsxt(service_user_prefix, cr_name, service, region, bb,
+                                                       path, latest_version, group)
+        except NSXTSkippedError as e:
+            self.assertEqual(f"NSXT: Cached management user for {bb} not authorized, refreshed cache for user. "
+                                   "Try again later.", str(e))
+
     @patch.object(NsxtUserAPIHelper, "connect")
     @patch.object(NsxtUserAPIHelper, "add_user_to_group")
     @patch.object(NsxtUserAPIHelper, "create_service_user")
     @patch.object(NsxtUserAPIHelper, "list_users")
     @patch.object(NsxtUserAPIHelper, "check_user_in_group")
-    def test_service_user_missing_in_nsxt(self, fn_user_group, fn_list, fn_create_user, fn_add_usergroup, fn_connect):
+    @patch.object(NSXTManagementCache, "get_secret")
+    def test_service_user_missing_in_nsxt(self, fn_get_secret, fn_user_group, fn_list, fn_create_user, fn_add_usergroup, fn_connect):
         management_user_secret = {
             "username": "admin",
             "password": "admin"
@@ -30,11 +62,11 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
 
         service_user_prefix = "userprefix"
         latest_version = "0002"
-        service = "nsxt"
+        service_type = "nsxt"
         cr_name = "exporter"
         bb = "bb085"
-        region = "qa-de-1"
-        path = f"{service}/{bb}"
+        region = "random"
+        path = f"{service_type}/{bb}"
         group = "blabbla"
 
         self.configurator.vault.get_secret.return_value = {
@@ -47,9 +79,10 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
         fn_create_user.return_value = True
         fn_add_usergroup.return_value = True
         fn_connect.return_value = True
+        fn_get_secret.return_value = management_user_secret
 
-        self.configurator._check_service_user_nsxt(service_user_prefix, cr_name, service, region, bb, path,
-                                                   latest_version, management_user_secret, group)
+        self.configurator._check_service_user_nsxt(service_user_prefix, cr_name, service_type, region, bb,
+                                                   path, latest_version, group)
 
         fn_list.assert_called_with(prefix=service_user_prefix)
         fn_create_user.assert_called_with(f"{service_user_prefix}{latest_version}", "test_password")
@@ -61,11 +94,11 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
             < time.time()
         )
 
-
     @patch.object(NsxtUserAPIHelper, "delete_service_user")
     @patch.object(NsxtUserAPIHelper, "list_users")
     @patch.object(NsxtUserAPIHelper, "check_user_in_group")
-    def test_stale_service_user(self, fn_user_group, fn_list, fn_delete):
+    @patch.object(NSXTManagementCache, "get_secret")
+    def test_stale_service_user(self, fn_get_secret, fn_user_group, fn_list, fn_delete):
         management_user_secret = {
             "username": "admin",
             "password": "admin"
@@ -73,11 +106,11 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
 
         service_user_prefix = "userprefix"
         latest_version = "2"
-        service = "nsxt"
+        service_type = "nsxt"
         cr_name = "exporter"
         bb = "bb085"
         region = "qa-de-1"
-        path = f"{service}/{bb}"
+        path = f"{service_type}/{bb}"
         group = "blabbla"
 
         self.configurator.vcenter_service_user_tracker = {
@@ -90,8 +123,10 @@ class TestNsxtServiceUserManagement(unittest.TestCase):
         fn_list.return_value = [f"{service_user_prefix}{latest_version.zfill(4)}", f"{service_user_prefix}001"]
         fn_user_group.return_value = True
         fn_delete.return_value = True
-        self.configurator._check_service_user_nsxt(service_user_prefix, cr_name, service, region, bb,
-                                                   path, latest_version, management_user_secret, group)
+        fn_get_secret.return_value = management_user_secret
+
+        self.configurator._check_service_user_nsxt(service_user_prefix, cr_name, service_type, region, bb,
+                                                   path, latest_version, group)
 
         # Stale entry should be removed
         assert "1" not in self.configurator.vcenter_service_user_tracker[cr_name][bb].keys(), \

--- a/tests/service_user_vcenter/test_service_user_vcenter.py
+++ b/tests/service_user_vcenter/test_service_user_vcenter.py
@@ -11,6 +11,7 @@ def configurator():
     """Fixture to create a Configurator instance with mocked dependencies"""
     global_options = {
         "dry_run": False,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/tests/service_user_vcenter/test_service_user_vcenter_deletion.py
+++ b/tests/service_user_vcenter/test_service_user_vcenter_deletion.py
@@ -11,6 +11,7 @@ def configurator():
     """Fixture to create a Configurator instance with mocked dependencies"""
     global_options = {
         "dry_run": False,
+        "region": "random",
     }
     domain = "test_domain"
 

--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from os.path import commonprefix
 
-import requests
 from kubernetes import client
 from kubernetes.client.models import V1ObjectMeta, V1Pod, V1PodList
 from masterpassword.masterpassword import MasterPassword
@@ -19,11 +18,12 @@ from pyVim.connect import Disconnect, SmartConnect
 from pyVmomi import vim
 
 import vcenter_operator.vcenter_util as vcu
-from vcenter_operator.nsxt_user_manager import NSXTSkippedError, NsxtUserAPIHelper
+from vcenter_operator.nsxt_user_manager import NotAuthorizedError, NSXTSkippedError, NsxtUserAPIHelper
 from vcenter_operator.phelm import DeploymentState
 from vcenter_operator.templates import env, vcenter_service_user_crd_loader
 from vcenter_operator.util import parse_buildingblock
 from vcenter_operator.vault import Vault, VaultSecretNotReplicatedError, VaultUnavailableError
+from vcenter_operator.vault_cache import NSXTCacheError, NSXTManagementCache
 from vcenter_operator.vcenter_sso import SSOSkippedError, VCenterSSO
 
 LOG = logging.getLogger(__name__)
@@ -33,10 +33,6 @@ class VcConnectionFailedError(Exception):
 
 
 class VcConnectSkippedError(Exception):
-    pass
-
-
-class NSXTManagementError(Exception):
     pass
 
 
@@ -82,6 +78,8 @@ class Configurator:
         self.vcenter_service_user_tracker = defaultdict(lambda: defaultdict(dict))
         self.states = dict()
         self.vault = Vault(dry_run=self.global_options.get('dry_run', 'False') == 'True')
+        self.nsxt_vaultcache = NSXTManagementCache(self.global_options['region'], self.vault,
+                                                   cache_lifetime=60 * 30)
         self.vcenter_sso = VCenterSSO(dry_run=self.global_options.get('dry_run', 'False') == 'True')
         self.global_options['cells'] = set()
         self.global_options['domain'] = domain
@@ -302,6 +300,11 @@ class Configurator:
             if self.vault_check_interval != vault_check_interval and vault_check_interval != "":
                 self.vault_check_interval = int(vault_check_interval)
 
+            # The interval (in seconds) before requesting the NSX-T user management password from Vault again
+            if nsxt_management_user_cache_lifetime := b64decode(
+                    secret.data.pop('nsxt_management_user_cache_lifetime', "")):
+                self.nsxt_vaultcache.cache_lifetime = int(nsxt_management_user_cache_lifetime)
+
             password_length = int(b64decode(secret.data.pop('password_length')))
             password_digits = int(b64decode(secret.data.pop('password_digits')))
             password_symbols = int(b64decode(secret.data.pop('password_symbols')))
@@ -448,8 +451,6 @@ class Configurator:
                 LOG.warning("Ignoring host %s for this run due to Vault not beeing replicated", host)
             except SSOSkippedError:
                 LOG.warning("Ignoring host %s for this run due to SSO being unavailable", host)
-            except NSXTManagementError as e:
-                LOG.warning(e)
             except http.client.HTTPException as e:
                 LOG.warning("%s: %r", host, e)
 
@@ -478,21 +479,6 @@ class Configurator:
                     # Required for accessing the nsxt management user path in vault
                     # and for the NSXT URL
                     bb_name = parse_buildingblock(vc_cluster.removeprefix("production"), leading_zero=True)
-                    management_user_path = "{}/compute/nsxt/nsx-ctl-1-{}.cc.{}.cloud.sap/nsxt-shell".format(
-                        self.global_options['region'], bb_name, self.global_options['region'])
-                    try:
-                        # Fetch from default path
-                        # For HTTP error > 500 raise VaultUnavailableError and handle in reconcile loop
-                        management_user = self.vault.get_secret(management_user_path)
-                    except requests.HTTPError as e:
-                        LOG.error("NSXT: Not able to fetch management user for nsxt shell user %s: %s",
-                                  management_user_path, e)
-                        continue
-
-                    if not management_user:
-                        LOG.error("NSXT: Could not read management user for service user creation: %s",
-                                  management_user_path)
-                        continue
 
                     path = f"{self.global_options['region']}/vcenter-operator/{cr_name}/{bb_name}"
                     LOG.debug("NSXT: Check service user %s %s %s", path, service_username_template, cr_name)
@@ -501,7 +487,7 @@ class Configurator:
                     try:
                         self._check_service_user_nsxt(service_username_template, cr_name, service_type,
                                                       self.global_options['region'], bb_name, path, latest_version,
-                                                      management_user, role="enterprise_admin")
+                                                      role="enterprise_admin")
                     except NSXTSkippedError as e:
                         LOG.error(e)
             else:
@@ -709,19 +695,33 @@ class Configurator:
 
             self.vcenter_service_user_tracker[cr_name][host][str(version)] = time.time()
 
+
     def _check_service_user_nsxt(self, service_user_prefix, cr_name, service_type, region, bb, path,
-                                 latest_version, management_user, role):
+                                 latest_version, role):
         """Check if service-user in NSXT is up-to-date"""
+
+        try:
+            management_user = self.nsxt_vaultcache.get_secret(bb)
+        except NSXTCacheError as e:
+            raise NSXTSkippedError(f"NSXT: An issue fetching the management user for {bb} occured") from e
+
+        if not management_user:
+            msg = f"NSXT: Could not read management user for service user creation: {bb}"
+            raise NSXTSkippedError(msg)
+
         current_username = service_user_prefix + str(latest_version).zfill(4)
         dry_run = self.global_options.get('dry_run', "False") == 'True'
         nsxt = NsxtUserAPIHelper(user=management_user["username"], password=management_user["password"],
                                  bb=bb, region=region, dry_run=dry_run)
-
         try:
             active_users = nsxt.list_users(prefix=service_user_prefix)
-        except Exception as e:
-            msg = f"Failed to list users - {e}"
-            raise NSXTSkippedError(msg)
+        except NotAuthorizedError:
+            try:
+                self.nsxt_vaultcache.renew_pw(bb)
+            except NSXTCacheError as e:
+                raise NSXTSkippedError(f"NSXT: An issue fetching the management user for {bb} occured") from e
+            raise NSXTSkippedError(f"NSXT: Cached management user for {bb} not authorized, refreshed cache for user. "
+                                   "Try again later.") from None
 
         # Create current user in NSXT
         if current_username not in active_users:

--- a/vcenter_operator/vault_cache.py
+++ b/vcenter_operator/vault_cache.py
@@ -1,0 +1,46 @@
+import logging
+import time
+from collections import defaultdict
+
+LOG = logging.getLogger(__name__)
+
+
+class NSXTCacheError(Exception):
+    pass
+
+
+class NSXTManagementCache:
+    management_user_path_template = "{region}/compute/nsxt/nsx-ctl-1-{bb}.cc.{region}.cloud.sap/nsxt-shell"
+
+    def __init__(self, region, vault, cache_lifetime=1800):
+        self.region = region
+        self.vault = vault
+        self.cache_lifetime = cache_lifetime
+        self.cache = defaultdict(dict)
+
+    def get_secret(self, bb):
+        secret_item = self.cache.get(bb)
+        if secret_item is None:
+            LOG.debug("Retrieving password for key %s", bb)
+            return self.renew_pw(bb)
+
+        if time.time() < secret_item["expiry"]:
+            return secret_item
+
+        try:
+            LOG.debug("Renewing password for key %s", bb)
+            return self.renew_pw(bb)
+        except NSXTCacheError as e:
+            LOG.error("Returning old, cached version because renewal failed: %s", e)
+            return secret_item
+
+    def renew_pw(self, bb):
+        management_user_path = self.management_user_path_template.format(region=self.region, bb=bb)
+        try:
+            vault_secret = self.vault.get_secret(management_user_path)
+        except Exception as e:
+            raise NSXTCacheError(f"NSXT: Not able to fetch management user"
+                                 f"for nsxt shell user {management_user_path}: {e}")
+        vault_secret["expiry"] = time.time() + self.cache_lifetime
+        self.cache[bb] = vault_secret
+        return vault_secret


### PR DESCRIPTION
 When reconciling service users, we fetch the NSX-T management user
 credentials in order to create NSX-T API users.
    
 In larger cloud regions, this process can place a significant load on the
 Vault API, since we retrieve an individual password
 for each BB during every reconciliation cycle.
    
 To reduce this load, we cache the retrieved passwords instead
 of requesting them repeatedly from Vault.