### PR TITLE
Make mpw optional

### DIFF
--- a/vcenter_operator/configurator.py
+++ b/vcenter_operator/configurator.py
@@ -358,17 +358,25 @@ class Configurator:
 
             self.vault.login()
 
-        password = b64decode(secret.data.pop('password'))
+        username = b64decode(secret.data.pop('username', '')) or None
+        password = b64decode(secret.data.pop('password', '')) or None
+
+        # MasterPassword usage is optional.
+        # If username/password are missing but MasterPassword is later required, an error will be
+        # raised at the point of use in _connect_vcenter.
+        if username and password:
+            self.global_options['username'] = username
+            if self.password != password:
+                self.global_options.update(master_password=password)
+                self.password = password
+                self.mpw = MasterPassword(self.username, self.password)
+        
         for key, value in secret.data.items():
             value = b64decode(value)
             try:
                 self.global_options[key] = json.loads(value)
             except ValueError:
                 self.global_options[key] = value
-        if self.password != password:
-            self.global_options.update(master_password=password)
-            self.password = password
-            self.mpw = MasterPassword(self.username, self.password)
 
     def _poll_nova_cells(self):
         """Fetch information about Nova's cells"""


### PR DESCRIPTION
If username and password is missing the masterpassword will not be initialized anymore. If it is still required during runtime, a check will raise an error.